### PR TITLE
Hotfix/add stag executable changes to genome mode 20210127

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,11 @@ Please check also the [wiki](https://github.com/zellerlab/stag/wiki) for more in
 
 <br/><br/><br/><br/>
 
-Installation
---------------
-```bash
-git clone https://github.com/zellerlab/stag.git
-cd stag
-export PATH=`pwd`:$PATH
-```
-
-Note: in the following examples we assume that the python script ```stag``` is in the system path.
-
-
-
 Dependencies
 --------------
 
 The stag classifier requires:
-* Python 3 (or higher)
+* Python 3.6 (or higher)
 * HMMER3 (or Infernal)
 * Easel ([link](https://github.com/EddyRivasLab/easel))
 * [seqtk](https://github.com/lh3/seqtk)
@@ -37,8 +25,27 @@ The stag classifier requires:
 If you have [conda](https://conda.io/docs/), you can install all the dependencies in `conda_env_stag.yaml`.
 See [Installation wiki](https://github.com/zellerlab/stag/wiki/Installation) for more info.
 
-You can test the correct installation of STAG with:
+
+Installation
+--------------
+```bash
+git clone https://github.com/zellerlab/stag.git
+cd stag
+# if environment is needed
+conda env create -f conda_env_stag.yaml
+python setup.py bdist_wheel
+pip install --no-deps --force-reinstall dist/*.whl
 ```
+
+Note: in the following examples we assume that the python script `stag` is in the system path.
+
+Execution
+---------
+
+```bash
+# if environment was installed
+conda activate stag
+# test the installation
 stag test
 ```
 

--- a/stag/classify_genome.py
+++ b/stag/classify_genome.py
@@ -397,10 +397,6 @@ def fetch_MGs(database_files, database_path, genomes_pred, keep_all_genes, gene_
 # ==============================================================================
 # TAXONOMICALLY ANNOTATE MARKER GENES
 # ==============================================================================
-# position of the script -------------------------------------------------------
-path_this = os.path.realpath(__file__)
-path_array = path_this.split("/")
-stag_path = "/".join(path_array[0:-2]) + "/stag"
 
 # we run stag classify, for each marker gene
 def annotate_MGs(MGS, database_files, database_base_path, dir_ali):
@@ -408,7 +404,7 @@ def annotate_MGs(MGS, database_files, database_base_path, dir_ali):
     for mg in MGS:
         if MGS[mg][0] != None:
             # it means that there are some genes to classify
-            CMD = stag_path + " classify -d "+database_base_path+"/"+mg
+            CMD = "stag classify -d "+database_base_path+"/"+mg
             # check that the database is correct
             if not os.path.isfile(database_base_path+"/"+mg):
                 sys.stderr.write("Error: file for gene database is missing")
@@ -517,7 +513,7 @@ def concat_alis(genomes_file_list, ali_dir, gene_order, ali_lengths):
 # ==============================================================================
 # the annotation for the genome is based on the annotation of the
 def annotate_concat_mgs(concat_ali_stag_db,file_ali,output):
-    CMD = stag_path + " classify -d "+concat_ali_stag_db
+    CMD = "stag classify -d "+concat_ali_stag_db
     CMD = CMD + " -s "+file_ali
     CMD = CMD + " -o "+output+"/genome_annotation"
 

--- a/stag/train_genome.py
+++ b/stag/train_genome.py
@@ -16,12 +16,6 @@ import h5py
 import re
 import tarfile
 
-# position of the script -------------------------------------------------------
-path_this = os.path.realpath(__file__)
-path_array = path_this.split("/")
-stag_path = "/".join(path_array[0:-2]) + "/stag"
-
-
 # function that checks if a file exists ----------------------------------------
 def check_file_exists(file_name, isfasta = False):
     try:
@@ -46,7 +40,7 @@ def find_length_ali(gene_db,temp_fasta,temp_fasta2):
     outfile = tempfile.NamedTemporaryFile(delete=False, mode="w")
     os.chmod(outfile.name, 0o644)
 
-    CMD = stag_path + " classify -d "+gene_db
+    CMD = "stag classify -d "+gene_db
     CMD = CMD + " -i "+temp_fasta
     CMD = CMD + " -p "+temp_fasta2
     CMD = CMD + " -S "+outfile.name


### PR DESCRIPTION
- `classify_genome` and `train_genome` were still using the path-hacking method to find the `stag` executable
-  updated README with install / run information